### PR TITLE
feat: Enable ingress mode with sidebar support and configurable port

### DIFF
--- a/homeassistant-time-machine/config.yaml
+++ b/homeassistant-time-machine/config.yaml
@@ -8,16 +8,25 @@
   "startup": "application",
   "boot": "auto",
   "init": false,
+  "ingress": true,
+  "ingress_port": 0,
+  "panel_icon": "mdi:backup-restore",
+  "panel_title": "Time Machine",
   "ports": {
     "3000/tcp": 3000
   },
   "ports_description": {
-    "3000/tcp": "Web interface"
+    "3000/tcp": "Web interface (fallback if not using ingress)"
   },
   "host_network": false,
   "map": [
     "config:rw",
     "media:rw"
   ],
-  "webui": "http://[HOST]:[PORT:3000]"
+  "options": {
+    "internal_port": 3000
+  },
+  "schema": {
+    "internal_port": "port"
+  }
 }


### PR DESCRIPTION
## Enable Ingress Mode with Sidebar Support and Configurable Port

### Summary
This update transforms the Home Assistant Time Machine add-on to open directly within the Home Assistant UI instead of opening in a new browser window/tab, providing a more seamless and integrated user experience.

### Changes Made
- **Enabled Ingress Mode**: The add-on now uses Home Assistant's ingress feature to embed the UI directly within the Home Assistant interface
- **Added Sidebar Integration**: The add-on now appears in the Home Assistant sidebar with:
  - Custom title: "Time Machine"
  - Icon: `mdi:backup-restore`
- **Configurable Port**: Added user-configurable internal port option (defaults to 3000) to prevent conflicts with other containers
  - Users can change the port in the add-on configuration settings if port 3000 is already in use
- **Maintained Fallback Access**: Kept external port mapping as a fallback option for direct access if needed

### Benefits
- 🎯 **Better UX**: No more switching between tabs/windows - access Time Machine directly from within Home Assistant
- 🎨 **Integrated UI**: Seamlessly blends into the Home Assistant interface
- ⚙️ **Flexible Configuration**: Port can be adjusted to avoid conflicts
- 📍 **Easy Access**: Quick access from the sidebar

### Technical Details
- `ingress`: Enabled for embedded UI
- `ingress_port`: Set to 0 (uses Home Assistant's ingress proxy)
- `panel_icon` & `panel_title`: Added for sidebar display
- `options` & `schema`: Added configurable internal port setting