### PR TITLE
Added scrollbar to settings window

### DIFF
--- a/homeassistant-time-machine/public/css/style.css
+++ b/homeassistant-time-machine/public/css/style.css
@@ -5,7 +5,16 @@
 }
 
 body {
-  font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family:
+    "Geist",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    sans-serif;
   background-color: #171717;
   color: #ededed;
   height: 100vh;
@@ -17,7 +26,7 @@ body {
   /* For absolute positioning of children */
 }
 
-body[data-theme='light'] {
+body[data-theme="light"] {
   background-color: #f3f4f6;
   color: #1f2937;
 }
@@ -62,7 +71,7 @@ html.theme-transition-suppress * {
   display: block;
 }
 
-body[data-theme='dark'] .logo {
+body[data-theme="dark"] .logo {
   filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.45));
   -webkit-filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.45));
 }
@@ -71,33 +80,32 @@ body[data-theme='dark'] .logo {
   font-size: 26px;
   font-weight: 600;
   margin-bottom: clamp(2px, 0.5vh, 6px);
-  color: #F9F9F9;
+  color: #f9f9f9;
   letter-spacing: -0.02em;
 }
 
-body[data-theme='light'] .header h1 {
+body[data-theme="light"] .header h1 {
   color: #111827;
 }
 
 .version {
   font-size: 14px;
-  color: #A2A2A2;
+  color: #a2a2a2;
   font-weight: 400;
   margin-top: -4px;
 }
 
-body[data-theme='light'] .version {
+body[data-theme="light"] .version {
   color: #4b5563;
 }
 
-
 .hero-subtitle,
 #heroSubtitle {
-  color: #A2A2A2;
+  color: #a2a2a2;
 }
 
-body[data-theme='light'] .hero-subtitle,
-body[data-theme='light'] #heroSubtitle {
+body[data-theme="light"] .hero-subtitle,
+body[data-theme="light"] #heroSubtitle {
   color: #6b7280;
 }
 
@@ -132,7 +140,7 @@ body[data-theme='light'] #heroSubtitle {
   display: none;
 }
 
-body[data-theme='light'] .tabs {
+body[data-theme="light"] .tabs {
   background-color: rgba(248, 250, 252, 0.9);
   border: 1px solid rgba(148, 163, 184, 0.2);
   box-shadow: 0 8px 20px -12px rgba(15, 23, 42, 0.35);
@@ -146,23 +154,23 @@ body[data-theme='light'] .tabs {
   border: none;
   cursor: pointer;
   background-color: transparent;
-  color: #A2A2A2;
+  color: #a2a2a2;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   height: clamp(36px, 5vh, 44px);
   flex: 0 0 auto;
   letter-spacing: -0.01em;
 }
 
-body[data-theme='light'] .tab {
+body[data-theme="light"] .tab {
   color: #475569;
 }
 
 .tab.active {
-  background: #007AFF;
-  color: #FAFAFA;
+  background: #007aff;
+  color: #fafafa;
 }
 
-body[data-theme='light'] .tab.active {
+body[data-theme="light"] .tab.active {
   color: white;
 }
 
@@ -183,7 +191,7 @@ body[data-theme='light'] .tab.active {
   overflow: hidden;
 }
 
-body[data-theme='light'] .panel {
+body[data-theme="light"] .panel {
   background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.22);
   box-shadow: 0 20px 32px -24px rgba(15, 23, 42, 0.22);
@@ -194,7 +202,7 @@ body[data-theme='light'] .panel {
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-body[data-theme='light'] .panel-header {
+body[data-theme="light"] .panel-header {
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
@@ -211,21 +219,21 @@ body[data-theme='light'] .panel-header {
   font-size: 19px;
   font-weight: 600;
   margin-bottom: clamp(2px, 0.5vh, 6px);
-  color: #F9F9F9;
+  color: #f9f9f9;
   letter-spacing: -0.02em;
 }
 
-body[data-theme='light'] .panel-header h2 {
+body[data-theme="light"] .panel-header h2 {
   color: #0f172a;
 }
 
 .panel-header p {
   font-size: 14px;
-  color: #A2A2A2;
+  color: #a2a2a2;
   font-weight: 400;
 }
 
-body[data-theme='light'] .panel-header p {
+body[data-theme="light"] .panel-header p {
   color: #6b7280;
 }
 
@@ -233,7 +241,7 @@ body[data-theme='light'] .panel-header p {
   color: #9ca3af;
 }
 
-body[data-theme='light'] #itemsSubtitle {
+body[data-theme="light"] #itemsSubtitle {
   color: #6b7280;
 }
 
@@ -255,12 +263,12 @@ body[data-theme='light'] #itemsSubtitle {
   background-color: rgba(35, 35, 35, 0.6);
   border: 1px solid rgba(231, 229, 228, 0.1);
   border-radius: 14px;
-  color: #E5E5E5;
+  color: #e5e5e5;
   font-size: 14px;
   transition: all 0.3s ease;
 }
 
-body[data-theme='light'] .search-input {
+body[data-theme="light"] .search-input {
   background: rgba(255, 255, 255, 0.96);
   border: 1px solid rgba(148, 163, 184, 0.12);
   color: #0f172a;
@@ -282,7 +290,7 @@ body[data-theme='light'] .search-input {
   pointer-events: none;
 }
 
-body[data-theme='light'] .search-icon {
+body[data-theme="light"] .search-icon {
   color: #94a3b8;
 }
 
@@ -304,11 +312,11 @@ body[data-theme='light'] .search-icon {
   margin-bottom: 12px;
 }
 
-body[data-theme='light'] .empty-state-icon {
+body[data-theme="light"] .empty-state-icon {
   background-color: rgba(148, 163, 184, 0.12);
 }
 
-body[data-theme='light'] .empty-state-icon__svg {
+body[data-theme="light"] .empty-state-icon__svg {
   color: #4b5563;
 }
 
@@ -322,7 +330,7 @@ body[data-theme='light'] .empty-state-icon__svg {
   color: #717171;
 }
 
-body[data-theme='light'] .search-input::placeholder {
+body[data-theme="light"] .search-input::placeholder {
   color: #9ca3af;
 }
 
@@ -331,7 +339,7 @@ body[data-theme='light'] .search-input::placeholder {
   background-color: rgba(35, 35, 35, 0.6);
   border: 1px solid rgba(231, 229, 228, 0.1);
   border-radius: 12px;
-  color: #D3D3D3;
+  color: #d3d3d3;
   font-size: 14px;
   cursor: pointer;
   -webkit-appearance: none;
@@ -339,7 +347,7 @@ body[data-theme='light'] .search-input::placeholder {
   outline: none;
   height: 40px;
   transition: all 0.3s ease;
-  background-image: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 fill=%27none%27 viewBox=%270 0 20 20%27%3e%3cpath stroke=%27%23A2A2A2%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%271.5%27 d=%27M6 8l4 4 4-4%27/%3e%3c/svg%3e');
+  background-image: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 fill=%27none%27 viewBox=%270 0 20 20%27%3e%3cpath stroke=%27%23A2A2A2%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%271.5%27 d=%27M6 8l4 4 4-4%27/%3e%3c/svg%3e");
   background-position: right 16px center;
   background-repeat: no-repeat;
   background-size: 1em;
@@ -347,14 +355,14 @@ body[data-theme='light'] .search-input::placeholder {
   box-shadow: none;
 }
 
-body[data-theme='light'] .select {
+body[data-theme="light"] .select {
   background: rgba(255, 255, 255, 0.96);
   border: 1px solid rgba(148, 163, 184, 0.3);
   color: #0f172a;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   -webkit-appearance: none;
   appearance: none;
-  background-image: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 fill=%27none%27 viewBox=%270 0 20 20%27%3e%3cpath stroke=%27%236b7280%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%271.5%27 d=%27M6 8l4 4 4-4%27/%3e%3c/svg%3e');
+  background-image: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 fill=%27none%27 viewBox=%270 0 20 20%27%3e%3cpath stroke=%27%236b7280%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%271.5%27 d=%27M6 8l4 4 4-4%27/%3e%3c/svg%3e");
   background-position: right 16px center;
   background-repeat: no-repeat;
   background-size: 1em;
@@ -366,7 +374,7 @@ body[data-theme='light'] .select {
   border-color: rgba(231, 229, 228, 0.15);
 }
 
-body[data-theme='light'] .select:hover {
+body[data-theme="light"] .select:hover {
   border-color: rgba(148, 163, 184, 0.2);
 }
 
@@ -397,7 +405,7 @@ li {
   background-color: rgb(56, 56, 56);
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(56, 56, 56, 0.8);
-  color: #D3D3D3;
+  color: #d3d3d3;
   margin-bottom: 10px;
   display: flex;
   align-items: center;
@@ -407,7 +415,7 @@ li {
   /* Allow item to shrink below content width */
 }
 
-body[data-theme='light'] .list-item {
+body[data-theme="light"] .list-item {
   background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.22);
   color: #475569;
@@ -426,12 +434,12 @@ body[data-theme='light'] .list-item {
 }
 
 /* Light Mode Override for Left Panel */
-body[data-theme='light'] #backupList .list-item {
+body[data-theme="light"] #backupList .list-item {
   background: #f1f5f9;
   /* Slate-100 - slightly darker than pure white */
 }
 
-body[data-theme='light'] #backupList .list-item:hover {
+body[data-theme="light"] #backupList .list-item:hover {
   background: #e2e8f0;
   /* Slate-200 */
 }
@@ -443,20 +451,22 @@ body[data-theme='light'] #backupList .list-item:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
-body[data-theme='light'] .list-item:hover {
+body[data-theme="light"] .list-item:hover {
   background: #ffffff;
   border-color: rgba(148, 163, 184, 0.3);
-  box-shadow: 0 16px 32px -22px rgba(15, 23, 42, 0.3), 0 6px 16px -12px rgba(15, 23, 42, 0.26);
+  box-shadow:
+    0 16px 32px -22px rgba(15, 23, 42, 0.3),
+    0 6px 16px -12px rgba(15, 23, 42, 0.26);
 }
 
 .list-item.active {
   background: #0070e6;
-  color: #FAFAFA;
+  color: #fafafa;
   box-shadow: none;
   border-color: transparent;
 }
 
-body[data-theme='light'] .list-item.active {
+body[data-theme="light"] .list-item.active {
   background: #0070e6;
   box-shadow: none;
   position: relative;
@@ -474,7 +484,7 @@ body[data-theme='light'] .list-item.active {
   /* Hide overflow */
 }
 
-.item-content>span {
+.item-content > span {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -498,7 +508,7 @@ body[data-theme='light'] .list-item.active {
 }
 
 .list-item.active .dot {
-  background-color: #FFF9F6;
+  background-color: #fff9f6;
 }
 
 .badge {
@@ -528,19 +538,19 @@ body[data-theme='light'] .list-item.active {
   border-color: rgba(34, 197, 94, 0.25);
 }
 
-body[data-theme='light'] .badge-changed {
+body[data-theme="light"] .badge-changed {
   background: rgba(249, 115, 22, 0.1);
   color: #c2410c;
   border-color: rgba(249, 115, 22, 0.16);
 }
 
-body[data-theme='light'] .badge-deleted {
+body[data-theme="light"] .badge-deleted {
   background: rgba(239, 68, 68, 0.1);
   color: #b91c1c;
   border-color: rgba(239, 68, 68, 0.16);
 }
 
-body[data-theme='light'] .badge-unchanged {
+body[data-theme="light"] .badge-unchanged {
   background: rgba(34, 197, 94, 0.1);
   color: #15803d;
   border-color: rgba(34, 197, 94, 0.16);
@@ -554,22 +564,22 @@ body[data-theme='light'] .badge-unchanged {
 }
 
 .list-item:hover .chevron {
-  color: #A2A2A2;
+  color: #a2a2a2;
 }
 
 .list-item.active .chevron {
-  color: #FAFAFA;
+  color: #fafafa;
 }
 
-body[data-theme='light'] .chevron {
+body[data-theme="light"] .chevron {
   color: #9ca3af;
 }
 
-body[data-theme='light'] .list-item:hover .chevron {
+body[data-theme="light"] .list-item:hover .chevron {
   color: #64748b;
 }
 
-body[data-theme='light'] .list-item.active .chevron {
+body[data-theme="light"] .list-item.active .chevron {
   color: #f8fafc;
 }
 
@@ -577,13 +587,13 @@ body[data-theme='light'] .list-item.active .chevron {
 .empty-state,
 .error {
   text-align: center;
-  color: #A2A2A2;
+  color: #a2a2a2;
   padding: 48px 24px;
   font-weight: 400;
 }
 
-body[data-theme='light'] .loading,
-body[data-theme='light'] .empty-state {
+body[data-theme="light"] .loading,
+body[data-theme="light"] .empty-state {
   color: #6b7280;
 }
 
@@ -616,11 +626,11 @@ body[data-theme='light'] .empty-state {
   color: #22c55e;
 }
 
-body[data-theme='light'] .backup-status-error {
+body[data-theme="light"] .backup-status-error {
   background: rgba(239, 68, 68, 0.12);
 }
 
-body[data-theme='light'] .backup-status-success {
+body[data-theme="light"] .backup-status-success {
   background: rgba(34, 197, 94, 0.12);
 }
 
@@ -638,9 +648,11 @@ body[data-theme='light'] .backup-status-success {
 
 .btn-primary {
   background: #0070e6;
-  color: #FAFAFA;
+  color: #fafafa;
   box-shadow: none;
-  transition: transform 0.2s ease, background-color 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    background-color 0.2s ease;
 }
 
 .btn-primary:hover {
@@ -651,18 +663,18 @@ body[data-theme='light'] .backup-status-success {
 
 .btn-secondary {
   background-color: rgba(35, 35, 35, 0.6);
-  color: #D3D3D3;
+  color: #d3d3d3;
   border: 1px solid rgba(231, 229, 228, 0.1);
 }
 
-body[data-theme='light'] .btn-secondary {
+body[data-theme="light"] .btn-secondary {
   background-color: rgb(246, 248, 251);
   color: #0f172a;
   border: 1px solid #e5e7eb;
   box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.24);
 }
 
-body[data-theme='light'] .btn-secondary:hover {
+body[data-theme="light"] .btn-secondary:hover {
   background-color: #ffffff;
   border-color: rgba(148, 163, 184, 0.18);
 }
@@ -676,7 +688,9 @@ body[data-theme='light'] .btn-secondary:hover {
   bottom: 0;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  padding: 16px;
+  overflow-y: auto;
   z-index: 1000;
 }
 
@@ -690,7 +704,7 @@ body[data-theme='light'] .btn-secondary:hover {
   backdrop-filter: blur(8px);
 }
 
-body[data-theme='light'] .modal-backdrop {
+body[data-theme="light"] .modal-backdrop {
   background: rgba(30, 41, 59, 0.35);
 }
 
@@ -708,7 +722,7 @@ body[data-theme='light'] .modal-backdrop {
   backdrop-filter: blur(20px);
 }
 
-body[data-theme='light'] .modal-dialog {
+body[data-theme="light"] .modal-dialog {
   background: rgba(255, 255, 255, 0.97);
   border: 1px solid rgba(148, 163, 184, 0.28);
   box-shadow: 0 28px 60px -24px rgba(15, 23, 42, 0.35);
@@ -730,11 +744,29 @@ body[data-theme='light'] .modal-dialog {
   border: 1px solid rgba(255, 255, 255, 0.05);
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   overflow-y: auto;
-  max-height: calc(90vh - 40px);
+  max-height: calc(100vh - 64px);
   scrollbar-width: none;
   /* Firefox */
   -ms-overflow-style: none;
   /* IE and Edge */
+}
+
+.settings-actions {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 18px;
+  padding-top: 10px;
+  background: rgba(35, 35, 35, 0.95);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  z-index: 10;
+}
+
+body[data-theme="light"] .settings-actions {
+  background: rgba(255, 255, 255, 0.95);
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -744,7 +776,7 @@ body[data-theme='light'] .modal-dialog {
   height: 0;
 }
 
-body[data-theme='light'] .settings-card {
+body[data-theme="light"] .settings-card {
   background-color: rgba(255, 255, 255, 0.95);
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 25px 55px -18px rgba(15, 23, 42, 0.28);
@@ -774,7 +806,7 @@ body[data-theme='light'] .settings-card {
   margin: 0;
 }
 
-body[data-theme='light'] .settings-header h2 {
+body[data-theme="light"] .settings-header h2 {
   color: #0f172a;
 }
 
@@ -785,11 +817,11 @@ body[data-theme='light'] .settings-header h2 {
   justify-content: space-between;
   align-items: center;
   background-color: rgba(45, 45, 45, 0.7);
-  color: #E5E5E5;
+  color: #e5e5e5;
   border-radius: 24px 24px 0 0;
 }
 
-body[data-theme='light'] .modal-header {
+body[data-theme="light"] .modal-header {
   background-color: rgba(248, 250, 252, 0.92);
   color: #0f172a;
   border-bottom: 1px solid rgba(203, 213, 225, 0.55);
@@ -804,7 +836,7 @@ body[data-theme='light'] .modal-header {
   font-size: 14px;
 }
 
-body[data-theme='light'] .modal-body {
+body[data-theme="light"] .modal-body {
   color: #475569;
   background-color: #fff;
 }
@@ -820,7 +852,7 @@ body[data-theme='light'] .modal-body {
   border-bottom-right-radius: 16px;
 }
 
-body[data-theme='light'] .modal-footer {
+body[data-theme="light"] .modal-footer {
   background-color: rgba(248, 250, 252, 0.92);
   border-top: 1px solid rgba(203, 213, 225, 0.55);
 }
@@ -834,7 +866,7 @@ body[data-theme='light'] .modal-footer {
   border-top: 1px solid rgba(231, 229, 228, 0.08);
 }
 
-body[data-theme='light'] .modal-actions {
+body[data-theme="light"] .modal-actions {
   border-top: 1px solid rgba(203, 213, 225, 0.55);
 }
 
@@ -844,7 +876,9 @@ body[data-theme='light'] .modal-actions {
   max-height: none;
   background-color: rgb(30, 30, 30);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 30px 60px -12px rgba(0, 0, 0, 0.5), 0 18px 36px -18px rgba(0, 0, 0, 0.5);
+  box-shadow:
+    0 30px 60px -12px rgba(0, 0, 0, 0.5),
+    0 18px 36px -18px rgba(0, 0, 0, 0.5);
 }
 
 .confirm-modal-header {
@@ -862,7 +896,7 @@ body[data-theme='light'] .modal-actions {
   justify-content: center;
   border-radius: 10px;
   background-color: rgba(0, 122, 252, 0.15);
-  color: #007AFC;
+  color: #007afc;
 }
 
 .confirm-btn-danger .confirm-icon-container,
@@ -908,21 +942,23 @@ body[data-theme='light'] .modal-actions {
 }
 
 /* Light Theme Overrides */
-body[data-theme='light'] .confirm-dialog {
+body[data-theme="light"] .confirm-dialog {
   background-color: #ffffff;
   border: 1px solid rgba(0, 0, 0, 0.08);
-  box-shadow: 0 30px 60px -12px rgba(15, 23, 42, 0.15), 0 18px 36px -18px rgba(15, 23, 42, 0.1);
+  box-shadow:
+    0 30px 60px -12px rgba(15, 23, 42, 0.15),
+    0 18px 36px -18px rgba(15, 23, 42, 0.1);
 }
 
-body[data-theme='light'] .confirm-modal-header h2 {
+body[data-theme="light"] .confirm-modal-header h2 {
   color: #1f2937;
 }
 
-body[data-theme='light'] .confirm-modal-body {
+body[data-theme="light"] .confirm-modal-body {
   color: #4b5563;
 }
 
-body[data-theme='light'] .confirm-icon-container {
+body[data-theme="light"] .confirm-icon-container {
   background-color: rgba(0, 122, 252, 0.08);
 }
 
@@ -936,7 +972,7 @@ body[data-theme='light'] .confirm-icon-container {
   border-bottom: 1px solid rgba(231, 229, 228, 0.08);
 }
 
-body[data-theme='light'] .diff-controls {
+body[data-theme="light"] .diff-controls {
   border-bottom: 1px solid rgba(203, 213, 225, 0.55);
 }
 
@@ -950,35 +986,35 @@ body[data-theme='light'] .diff-controls {
 
 .status-unchanged {
   background: rgba(200, 200, 200, 0.15);
-  color: #C8C8C8;
+  color: #c8c8c8;
   border: 1px solid rgba(200, 200, 200, 0.25);
 }
 
 .status-changed {
   background: rgba(196, 196, 196, 0.15);
-  color: #C4C4C4;
+  color: #c4c4c4;
   border: 1px solid rgba(196, 196, 196, 0.25);
 }
 
 .status-deleted {
   background: rgba(191, 191, 191, 0.15);
-  color: #BFBFBF;
+  color: #bfbfbf;
   border: 1px solid rgba(191, 191, 191, 0.25);
 }
 
-body[data-theme='light'] .status-unchanged {
+body[data-theme="light"] .status-unchanged {
   background: rgba(226, 232, 240, 0.8);
   color: #475569;
   border-color: rgba(203, 213, 225, 0.8);
 }
 
-body[data-theme='light'] .status-changed {
+body[data-theme="light"] .status-changed {
   background: rgba(254, 226, 226, 0.8);
   color: #b91c1c;
   border-color: rgba(254, 202, 202, 0.8);
 }
 
-body[data-theme='light'] .status-deleted {
+body[data-theme="light"] .status-deleted {
   background: rgba(254, 242, 242, 0.85);
   color: #dc2626;
   border-color: rgba(254, 215, 215, 0.85);
@@ -991,7 +1027,11 @@ body[data-theme='light'] .status-deleted {
 }
 
 .diff-column {
-  background: linear-gradient(135deg, rgba(25, 25, 25, 0.6) 0%, rgba(20, 18, 17, 0.4) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(25, 25, 25, 0.6) 0%,
+    rgba(20, 18, 17, 0.4) 100%
+  );
   border-radius: 16px;
   overflow: hidden;
   border: 1px solid rgba(231, 229, 228, 0.06);
@@ -1004,7 +1044,7 @@ body[data-theme='light'] .status-deleted {
   box-sizing: border-box;
 }
 
-body[data-theme='light'] .diff-column {
+body[data-theme="light"] .diff-column {
   background: #ffffff;
   border: 1px solid rgba(203, 213, 225, 0.5);
   box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.1);
@@ -1014,14 +1054,18 @@ body[data-theme='light'] .diff-column {
   font-size: 14px;
   font-weight: 500;
   padding: clamp(10px, 1.5vh, 16px) clamp(12px, 1.8vh, 20px);
-  background: linear-gradient(135deg, rgba(35, 35, 35, 0.8) 0%, rgba(25, 25, 25, 0.6) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(35, 35, 35, 0.8) 0%,
+    rgba(25, 25, 25, 0.6) 100%
+  );
   border-bottom: 1px solid rgba(231, 229, 228, 0.08);
   margin: 0;
-  color: #E5E5E5;
+  color: #e5e5e5;
   letter-spacing: -0.01em;
 }
 
-body[data-theme='light'] .diff-column h3 {
+body[data-theme="light"] .diff-column h3 {
   background: #f8fafc;
   border-bottom: 1px solid rgba(203, 213, 225, 0.6);
   color: #0f172a;
@@ -1030,7 +1074,7 @@ body[data-theme='light'] .diff-column h3 {
 .diff-content {
   background: #1e1e1e;
   color: #e0e0e0;
-  font-family: 'Fira Code', 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+  font-family: "Fira Code", "SF Mono", "Menlo", "Monaco", "Consolas", monospace;
   font-size: 13px;
   line-height: 1.5;
   padding: clamp(10px, 2vh, 20px);
@@ -1043,13 +1087,13 @@ body[data-theme='light'] .diff-column h3 {
   box-sizing: border-box;
 }
 
-body[data-theme='light'] .diff-content {
+body[data-theme="light"] .diff-content {
   background: #ffffff;
   color: #1f2937;
   border-radius: 0 0 16px 16px;
 }
 
-body[data-theme='light'] .yaml-content {
+body[data-theme="light"] .yaml-content {
   color: #1f2937;
   background: #ffffff;
 }
@@ -1057,16 +1101,16 @@ body[data-theme='light'] .yaml-content {
 .yaml-content {
   padding: clamp(10px, 2vh, 20px);
   margin: 0;
-  font-family: 'SF Mono', 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-family: "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
   font-size: 13px;
   line-height: 1.7;
-  color: #D3D3D3;
+  color: #d3d3d3;
   overflow-x: auto;
   white-space: pre-wrap;
   word-wrap: break-word;
 }
 
-body[data-theme='light'] .yaml-content {
+body[data-theme="light"] .yaml-content {
   background: #ffffff;
   color: #1e293b;
 }
@@ -1090,20 +1134,20 @@ body[data-theme='light'] .yaml-content {
   font-size: 14px;
 }
 
-body[data-theme='light'] .settings-card,
-body[data-theme='light'] .settings-card label,
-body[data-theme='light'] .settings-card .settings-inline-text,
-body[data-theme='light'] .settings-card .settings-inline-btn,
-body[data-theme='light'] .settings-card .settings-error-text,
-body[data-theme='light'] .settings-card .settings-inline-text.status-success {
+body[data-theme="light"] .settings-card,
+body[data-theme="light"] .settings-card label,
+body[data-theme="light"] .settings-card .settings-inline-text,
+body[data-theme="light"] .settings-card .settings-inline-btn,
+body[data-theme="light"] .settings-card .settings-error-text,
+body[data-theme="light"] .settings-card .settings-inline-text.status-success {
   color: #111827;
 }
 
-body[data-theme='light'] .settings-card .settings-inline-text.status-success {
+body[data-theme="light"] .settings-card .settings-inline-text.status-success {
   color: #16a34a;
 }
 
-body[data-theme='light'] .settings-card .settings-inline-text.status-error {
+body[data-theme="light"] .settings-card .settings-inline-text.status-error {
   color: #dc2626;
 }
 
@@ -1124,11 +1168,11 @@ body[data-theme='light'] .settings-card .settings-inline-text.status-error {
   transition: border-color 0.2s;
 }
 
-body[data-theme='light'] .form-group input[type="text"],
-body[data-theme='light'] .form-group input[type="password"],
-body[data-theme='light'] .form-group input[type="time"],
-body[data-theme='light'] .form-group input[type="number"],
-body[data-theme='light'] .form-group select {
+body[data-theme="light"] .form-group input[type="text"],
+body[data-theme="light"] .form-group input[type="password"],
+body[data-theme="light"] .form-group input[type="time"],
+body[data-theme="light"] .form-group input[type="number"],
+body[data-theme="light"] .form-group select {
   background-color: rgba(255, 255, 255, 0.96);
   border: 1px solid rgba(148, 163, 184, 0.14);
   color: #4b5563;
@@ -1156,14 +1200,14 @@ body[data-theme='light'] .form-group select {
   padding-right: 42px;
 }
 
-body[data-theme='light'] .form-group select {
+body[data-theme="light"] .form-group select {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%234b5563' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.8' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
   background-color: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.3);
   color: #1f2937;
 }
 
-body[data-theme='light'] .form-group select:focus {
+body[data-theme="light"] .form-group select:focus {
   border-color: rgba(59, 130, 246, 0.5);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
 }
@@ -1201,11 +1245,11 @@ body[data-theme='light'] .form-group select:focus {
   font-weight: 500;
   font-size: 14px;
   background-color: rgba(56, 56, 56, 0.8);
-  color: #D3D3D3;
+  color: #d3d3d3;
   border: 1px solid rgba(231, 229, 228, 0.1);
 }
 
-body[data-theme='light'] .settings-inline-btn {
+body[data-theme="light"] .settings-inline-btn {
   background-color: rgba(255, 255, 255, 0.95);
   color: #0f172a;
   border: 1px solid rgba(148, 163, 184, 0.12);
@@ -1215,20 +1259,20 @@ body[data-theme='light'] .settings-inline-btn {
 .settings-inline-text {
   margin-top: 4px;
   font-size: 13px;
-  color: #A2A2A2;
+  color: #a2a2a2;
   min-width: 140px;
   display: inline-block;
 }
 
-body[data-theme='light'] .settings-inline-text {
+body[data-theme="light"] .settings-inline-text {
   color: #475569;
 }
 
-body[data-theme='light'] .settings-inline-text.status-success {
+body[data-theme="light"] .settings-inline-text.status-success {
   color: #16a34a;
 }
 
-body[data-theme='light'] .settings-inline-text.status-error {
+body[data-theme="light"] .settings-inline-text.status-error {
   color: #dc2626;
 }
 
@@ -1240,7 +1284,7 @@ body[data-theme='light'] .settings-inline-text.status-error {
   line-height: 1.4;
 }
 
-body[data-theme='light'] .settings-error-text {
+body[data-theme="light"] .settings-error-text {
   color: #b91c1c;
 }
 
@@ -1254,7 +1298,7 @@ body[data-theme='light'] .settings-error-text {
   margin: 20px 0 16px;
 }
 
-body[data-theme='light'] .settings-divider {
+body[data-theme="light"] .settings-divider {
   border-top: 1px solid rgba(203, 213, 225, 0.55);
 }
 
@@ -1313,13 +1357,6 @@ body[data-theme='light'] .settings-divider {
   appearance: textfield;
 }
 
-.settings-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-  margin-top: 20px;
-}
-
 /* Toggle Switch - Claude Style */
 .toggle-group {
   display: flex;
@@ -1359,25 +1396,25 @@ body[data-theme='light'] .settings-divider {
   width: 22px;
   left: 3px;
   bottom: 3px;
-  background-color: #E7E5E4;
+  background-color: #e7e5e4;
   transition: 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: 50%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-.toggle input:checked+.toggle-slider {
-  background: #007AFF;
+.toggle input:checked + .toggle-slider {
+  background: #007aff;
 }
 
-.toggle input:checked+.toggle-slider:before {
+.toggle input:checked + .toggle-slider:before {
   transform: translateX(22px);
 }
 
-body[data-theme='light'] .toggle-slider {
+body[data-theme="light"] .toggle-slider {
   background-color: rgba(148, 163, 184, 0.35);
 }
 
-body[data-theme='light'] .toggle-slider:before {
+body[data-theme="light"] .toggle-slider:before {
   background-color: #ffffff;
   box-shadow: 0 2px 6px rgba(148, 163, 184, 0.35);
 }
@@ -1389,7 +1426,7 @@ body[data-theme='light'] .toggle-slider:before {
   right: 24px;
   padding: 16px 28px;
   border-radius: 14px;
-  color: #FAFAFA;
+  color: #fafafa;
   font-weight: 500;
   z-index: 2000;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
@@ -1398,7 +1435,7 @@ body[data-theme='light'] .toggle-slider:before {
   backdrop-filter: blur(12px);
 }
 
-body[data-theme='light'] .notification {
+body[data-theme="light"] .notification {
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 16px 34px -18px rgba(15, 23, 42, 0.35);
   color: #0f172a;
@@ -1410,7 +1447,7 @@ body[data-theme='light'] .notification {
   text-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
 }
 
-body[data-theme='light'] .notification.success {
+body[data-theme="light"] .notification.success {
   background: #22c55e;
   color: #ffffff;
 }
@@ -1419,7 +1456,7 @@ body[data-theme='light'] .notification.success {
   background: rgba(239, 68, 68, 0.95);
 }
 
-body[data-theme='light'] .notification.error {
+body[data-theme="light"] .notification.error {
   background: #ef4444;
   color: #ffffff;
 }
@@ -1428,7 +1465,7 @@ body[data-theme='light'] .notification.error {
   background: rgba(0, 122, 255, 0.95);
 }
 
-body[data-theme='light'] .notification.info {
+body[data-theme="light"] .notification.info {
   background: #3b82f6;
   color: #ffffff;
 }
@@ -1446,7 +1483,7 @@ body[data-theme='light'] .notification.info {
   margin-bottom: 16px;
 }
 
-body[data-theme='light'] .diff-state-banner {
+body[data-theme="light"] .diff-state-banner {
   border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
@@ -1456,7 +1493,7 @@ body[data-theme='light'] .diff-state-banner {
   border-color: rgba(239, 68, 68, 0.25);
 }
 
-body[data-theme='light'] .diff-state-banner-deleted {
+body[data-theme="light"] .diff-state-banner-deleted {
   background-color: rgba(254, 226, 226, 0.8);
   color: #b91c1c;
   border-color: rgba(254, 202, 202, 0.8);
@@ -1468,7 +1505,7 @@ body[data-theme='light'] .diff-state-banner-deleted {
   border-color: rgba(34, 197, 94, 0.25);
 }
 
-body[data-theme='light'] .diff-state-banner-unchanged {
+body[data-theme="light"] .diff-state-banner-unchanged {
   background: rgba(220, 252, 231, 0.8);
   color: #15803d;
   border-color: rgba(187, 247, 208, 0.8);
@@ -1480,7 +1517,7 @@ body[data-theme='light'] .diff-state-banner-unchanged {
   border-color: rgba(59, 130, 246, 0.25);
 }
 
-body[data-theme='light'] .diff-state-banner-changed {
+body[data-theme="light"] .diff-state-banner-changed {
   background: rgba(219, 234, 254, 0.8);
   color: #1d4ed8;
   border-color: rgba(191, 219, 254, 0.8);
@@ -1490,11 +1527,11 @@ body[data-theme='light'] .diff-state-banner-changed {
 
 [data-diff-palette="2"] .diff-state-banner-changed {
   background-color: rgba(0, 191, 165, 0.18);
-  color: #00BFA5;
+  color: #00bfa5;
   border-color: rgba(0, 191, 165, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="2"] .diff-state-banner-changed {
+body[data-theme="light"] [data-diff-palette="2"] .diff-state-banner-changed {
   background-color: rgba(0, 191, 165, 0.12);
   color: #00897b;
   border-color: rgba(0, 191, 165, 0.25);
@@ -1502,11 +1539,11 @@ body[data-theme='light'] [data-diff-palette="2"] .diff-state-banner-changed {
 
 [data-diff-palette="3"] .diff-state-banner-changed {
   background-color: rgba(0, 172, 193, 0.18);
-  color: #00ACC1;
+  color: #00acc1;
   border-color: rgba(0, 172, 193, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="3"] .diff-state-banner-changed {
+body[data-theme="light"] [data-diff-palette="3"] .diff-state-banner-changed {
   background-color: rgba(0, 172, 193, 0.12);
   color: #0097a7;
   border-color: rgba(0, 172, 193, 0.25);
@@ -1514,11 +1551,11 @@ body[data-theme='light'] [data-diff-palette="3"] .diff-state-banner-changed {
 
 [data-diff-palette="4"] .diff-state-banner-changed {
   background-color: rgba(118, 255, 3, 0.15);
-  color: #76FF03;
+  color: #76ff03;
   border-color: rgba(118, 255, 3, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="4"] .diff-state-banner-changed {
+body[data-theme="light"] [data-diff-palette="4"] .diff-state-banner-changed {
   background-color: rgba(76, 175, 80, 0.12);
   color: #388e3c;
   border-color: rgba(76, 175, 80, 0.25);
@@ -1526,11 +1563,11 @@ body[data-theme='light'] [data-diff-palette="4"] .diff-state-banner-changed {
 
 [data-diff-palette="5"] .diff-state-banner-changed {
   background-color: rgba(32, 178, 170, 0.2);
-  color: #20B2AA;
+  color: #20b2aa;
   border-color: rgba(32, 178, 170, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="5"] .diff-state-banner-changed {
+body[data-theme="light"] [data-diff-palette="5"] .diff-state-banner-changed {
   background-color: rgba(32, 178, 170, 0.12);
   color: #26a69a;
   border-color: rgba(32, 178, 170, 0.25);
@@ -1538,11 +1575,11 @@ body[data-theme='light'] [data-diff-palette="5"] .diff-state-banner-changed {
 
 [data-diff-palette="6"] .diff-state-banner-changed {
   background-color: rgba(46, 125, 50, 0.2);
-  color: #4CAF50;
+  color: #4caf50;
   border-color: rgba(46, 125, 50, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="6"] .diff-state-banner-changed {
+body[data-theme="light"] [data-diff-palette="6"] .diff-state-banner-changed {
   background-color: rgba(46, 125, 50, 0.12);
   color: #2e7d32;
   border-color: rgba(46, 125, 50, 0.25);
@@ -1550,11 +1587,11 @@ body[data-theme='light'] [data-diff-palette="6"] .diff-state-banner-changed {
 
 [data-diff-palette="7"] .diff-state-banner-changed {
   background-color: rgba(77, 208, 225, 0.18);
-  color: #4DD0E1;
+  color: #4dd0e1;
   border-color: rgba(77, 208, 225, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="7"] .diff-state-banner-changed {
+body[data-theme="light"] [data-diff-palette="7"] .diff-state-banner-changed {
   background-color: rgba(6, 182, 212, 0.12);
   color: #0891b2;
   border-color: rgba(6, 182, 212, 0.25);
@@ -1562,11 +1599,11 @@ body[data-theme='light'] [data-diff-palette="7"] .diff-state-banner-changed {
 
 [data-diff-palette="8"] .diff-state-banner-changed {
   background-color: rgba(0, 229, 255, 0.15);
-  color: #00E5FF;
+  color: #00e5ff;
   border-color: rgba(0, 229, 255, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="8"] .diff-state-banner-changed {
+body[data-theme="light"] [data-diff-palette="8"] .diff-state-banner-changed {
   background-color: rgba(6, 182, 212, 0.12);
   color: #0891b2;
   border-color: rgba(6, 182, 212, 0.25);
@@ -1590,7 +1627,7 @@ hr {
   margin: 28px 0;
 }
 
-body[data-theme='light'] hr {
+body[data-theme="light"] hr {
   border-top: 1px solid rgba(203, 213, 225, 0.55);
 }
 
@@ -1598,11 +1635,11 @@ h3 {
   font-size: 17px;
   font-weight: 600;
   margin-bottom: 20px;
-  color: #F9F9F9;
+  color: #f9f9f9;
   letter-spacing: -0.02em;
 }
 
-body[data-theme='light'] h3 {
+body[data-theme="light"] h3 {
   color: #0f172a;
 }
 
@@ -1611,7 +1648,7 @@ body[data-theme='light'] h3 {
   display: none;
 }
 
-body[data-theme='light'] .diff-palette-bar {
+body[data-theme="light"] .diff-palette-bar {
   display: none;
 }
 
@@ -1630,7 +1667,7 @@ body[data-theme='light'] .diff-palette-bar {
   margin-right: 4px;
 }
 
-body[data-theme='light'] .diff-palette-label {
+body[data-theme="light"] .diff-palette-label {
   color: rgba(0, 0, 0, 0.5);
 }
 
@@ -1767,11 +1804,11 @@ body[data-theme='light'] .diff-palette-label {
 }
 
 [data-diff-palette="2"] .diff-line-removed .diff-line-marker {
-  color: #E91E63;
+  color: #e91e63;
 }
 
 [data-diff-palette="2"] .diff-line-added .diff-line-marker {
-  color: #00BFA5;
+  color: #00bfa5;
 }
 
 [data-diff-palette="3"] .diff-line-removed {
@@ -1783,11 +1820,11 @@ body[data-theme='light'] .diff-palette-label {
 }
 
 [data-diff-palette="3"] .diff-line-removed .diff-line-marker {
-  color: #FF5722;
+  color: #ff5722;
 }
 
 [data-diff-palette="3"] .diff-line-added .diff-line-marker {
-  color: #00ACC1;
+  color: #00acc1;
 }
 
 [data-diff-palette="4"] .diff-line-removed {
@@ -1799,11 +1836,11 @@ body[data-theme='light'] .diff-palette-label {
 }
 
 [data-diff-palette="4"] .diff-line-removed .diff-line-marker {
-  color: #9C27B0;
+  color: #9c27b0;
 }
 
 [data-diff-palette="4"] .diff-line-added .diff-line-marker {
-  color: #76FF03;
+  color: #76ff03;
 }
 
 [data-diff-palette="5"] .diff-line-removed {
@@ -1815,11 +1852,11 @@ body[data-theme='light'] .diff-palette-label {
 }
 
 [data-diff-palette="5"] .diff-line-removed .diff-line-marker {
-  color: #FA8072;
+  color: #fa8072;
 }
 
 [data-diff-palette="5"] .diff-line-added .diff-line-marker {
-  color: #20B2AA;
+  color: #20b2aa;
 }
 
 [data-diff-palette="6"] .diff-line-removed {
@@ -1831,11 +1868,11 @@ body[data-theme='light'] .diff-palette-label {
 }
 
 [data-diff-palette="6"] .diff-line-removed .diff-line-marker {
-  color: #C62828;
+  color: #c62828;
 }
 
 [data-diff-palette="6"] .diff-line-added .diff-line-marker {
-  color: #2E7D32;
+  color: #2e7d32;
 }
 
 [data-diff-palette="7"] .diff-line-removed {
@@ -1847,11 +1884,11 @@ body[data-theme='light'] .diff-palette-label {
 }
 
 [data-diff-palette="7"] .diff-line-removed .diff-line-marker {
-  color: #FFAB91;
+  color: #ffab91;
 }
 
 [data-diff-palette="7"] .diff-line-added .diff-line-marker {
-  color: #4DD0E1;
+  color: #4dd0e1;
 }
 
 [data-diff-palette="8"] .diff-line-removed {
@@ -1863,157 +1900,215 @@ body[data-theme='light'] .diff-palette-label {
 }
 
 [data-diff-palette="8"] .diff-line-removed .diff-line-marker {
-  color: #FF4081;
+  color: #ff4081;
 }
 
 [data-diff-palette="8"] .diff-line-added .diff-line-marker {
-  color: #00E5FF;
+  color: #00e5ff;
 }
 
 /* Light mode palette overrides - stronger colors for visibility */
 /* Palette 1: Original colors with alternating for light mode */
-body[data-theme='light'] [data-diff-palette="1"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="1"] .diff-line-removed {
   background: rgba(220, 38, 38, 0.18);
 }
 
-body[data-theme='light'] [data-diff-palette="1"] .diff-row:nth-child(even) .diff-line-removed {
+body[data-theme="light"]
+  [data-diff-palette="1"]
+  .diff-row:nth-child(even)
+  .diff-line-removed {
   background: rgba(220, 38, 38, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="1"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="1"] .diff-line-added {
   background: rgba(22, 163, 74, 0.15);
 }
 
-body[data-theme='light'] [data-diff-palette="1"] .diff-row:nth-child(even) .diff-line-added {
+body[data-theme="light"]
+  [data-diff-palette="1"]
+  .diff-row:nth-child(even)
+  .diff-line-added {
   background: rgba(22, 163, 74, 0.22);
 }
 
-body[data-theme='light'] [data-diff-palette="1"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="1"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #dc2626;
 }
 
-body[data-theme='light'] [data-diff-palette="1"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="1"]
+  .diff-line-added
+  .diff-line-marker {
   color: #16a34a;
 }
 
-body[data-theme='light'] [data-diff-palette="2"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="2"] .diff-line-removed {
   background: rgba(233, 30, 99, 0.18);
 }
 
-body[data-theme='light'] [data-diff-palette="2"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="2"] .diff-line-added {
   background: rgba(0, 191, 165, 0.18);
 }
 
-body[data-theme='light'] [data-diff-palette="2"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="2"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #c2185b;
 }
 
-body[data-theme='light'] [data-diff-palette="2"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="2"]
+  .diff-line-added
+  .diff-line-marker {
   color: #00897b;
 }
 
-body[data-theme='light'] [data-diff-palette="3"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="3"] .diff-line-removed {
   background: rgba(255, 87, 34, 0.2);
 }
 
-body[data-theme='light'] [data-diff-palette="3"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="3"] .diff-line-added {
   background: rgba(0, 172, 193, 0.2);
 }
 
-body[data-theme='light'] [data-diff-palette="3"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="3"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #e64a19;
 }
 
-body[data-theme='light'] [data-diff-palette="3"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="3"]
+  .diff-line-added
+  .diff-line-marker {
   color: #0097a7;
 }
 
-body[data-theme='light'] [data-diff-palette="4"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="4"] .diff-line-removed {
   background: rgba(156, 39, 176, 0.18);
 }
 
-body[data-theme='light'] [data-diff-palette="4"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="4"] .diff-line-added {
   background: rgba(76, 175, 80, 0.2);
 }
 
-body[data-theme='light'] [data-diff-palette="4"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="4"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #7b1fa2;
 }
 
-body[data-theme='light'] [data-diff-palette="4"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="4"]
+  .diff-line-added
+  .diff-line-marker {
   color: #388e3c;
 }
 
-body[data-theme='light'] [data-diff-palette="5"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="5"] .diff-line-removed {
   background: rgba(250, 128, 114, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="5"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="5"] .diff-line-added {
   background: rgba(32, 178, 170, 0.22);
 }
 
-body[data-theme='light'] [data-diff-palette="5"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="5"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #e57373;
 }
 
-body[data-theme='light'] [data-diff-palette="5"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="5"]
+  .diff-line-added
+  .diff-line-marker {
   color: #26a69a;
 }
 
-body[data-theme='light'] [data-diff-palette="6"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="6"] .diff-line-removed {
   background: rgba(198, 40, 40, 0.2);
 }
 
-body[data-theme='light'] [data-diff-palette="6"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="6"] .diff-line-added {
   background: rgba(46, 125, 50, 0.2);
 }
 
-body[data-theme='light'] [data-diff-palette="6"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="6"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #c62828;
 }
 
-body[data-theme='light'] [data-diff-palette="6"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="6"]
+  .diff-line-added
+  .diff-line-marker {
   color: #2e7d32;
 }
 
-body[data-theme='light'] [data-diff-palette="7"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="7"] .diff-line-removed {
   background: rgba(239, 68, 68, 0.18);
 }
 
-body[data-theme='light'] [data-diff-palette="7"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="7"] .diff-line-added {
   background: rgba(6, 182, 212, 0.2);
 }
 
-body[data-theme='light'] [data-diff-palette="7"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="7"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #ef4444;
 }
 
-body[data-theme='light'] [data-diff-palette="7"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="7"]
+  .diff-line-added
+  .diff-line-marker {
   color: #0891b2;
 }
 
-body[data-theme='light'] [data-diff-palette="8"] .diff-line-removed {
+body[data-theme="light"] [data-diff-palette="8"] .diff-line-removed {
   background: rgba(236, 72, 153, 0.18);
 }
 
-body[data-theme='light'] [data-diff-palette="8"] .diff-line-added {
+body[data-theme="light"] [data-diff-palette="8"] .diff-line-added {
   background: rgba(6, 182, 212, 0.18);
 }
 
-body[data-theme='light'] [data-diff-palette="8"] .diff-line-removed .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="8"]
+  .diff-line-removed
+  .diff-line-marker {
   color: #db2777;
 }
 
-body[data-theme='light'] [data-diff-palette="8"] .diff-line-added .diff-line-marker {
+body[data-theme="light"]
+  [data-diff-palette="8"]
+  .diff-line-added
+  .diff-line-marker {
   color: #0891b2;
 }
 
 /* Diff Viewer - Split Layout */
 .diff-viewer-shell {
-  background: linear-gradient(135deg, rgba(22, 22, 22, 0.95) 0%, rgba(14, 14, 14, 0.92) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(22, 22, 22, 0.95) 0%,
+    rgba(14, 14, 14, 0.92) 100%
+  );
   border-radius: 16px;
   overflow: hidden;
-  font-family: 'Fira Code', 'JetBrains Mono', 'SF Mono', 'Monaco', monospace;
+  font-family: "Fira Code", "JetBrains Mono", "SF Mono", "Monaco", monospace;
   font-size: 13px;
   line-height: 1.45;
   height: 100%;
@@ -2021,7 +2116,7 @@ body[data-theme='light'] [data-diff-palette="8"] .diff-line-added .diff-line-mar
   flex-direction: column;
 }
 
-body[data-theme='light'] .diff-viewer-shell {
+body[data-theme="light"] .diff-viewer-shell {
   background: #ffffff;
 }
 
@@ -2035,7 +2130,7 @@ body[data-theme='light'] .diff-viewer-shell {
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-body[data-theme='light'] .diff-compare-banner {
+body[data-theme="light"] .diff-compare-banner {
   background: #f8fafc;
   border-bottom: 1px solid rgba(203, 213, 225, 0.5);
 }
@@ -2053,7 +2148,7 @@ body[data-theme='light'] .diff-compare-banner {
   color: #d1d5db;
 }
 
-body[data-theme='light'] .diff-compare-pill {
+body[data-theme="light"] .diff-compare-pill {
   background: rgba(241, 245, 249, 0.85);
   border-color: rgba(148, 163, 184, 0.35);
   color: #0f172a;
@@ -2066,7 +2161,7 @@ body[data-theme='light'] .diff-compare-pill {
   box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.2);
 }
 
-body[data-theme='light'] .diff-compare-pill-accent {
+body[data-theme="light"] .diff-compare-pill-accent {
   background: rgba(59, 130, 246, 0.22);
   border-color: rgba(59, 130, 246, 0.35);
   color: #1d4ed8;
@@ -2081,7 +2176,7 @@ body[data-theme='light'] .diff-compare-pill-accent {
   flex-direction: column;
 }
 
-body[data-theme='light'] .diff-viewer-split {
+body[data-theme="light"] .diff-viewer-split {
   background: #ffffff;
 }
 
@@ -2100,7 +2195,7 @@ body[data-theme='light'] .diff-viewer-split {
   flex: 1;
 }
 
-body[data-theme='light'] .diff-hunk {
+body[data-theme="light"] .diff-hunk {
   background: #ffffff;
 }
 
@@ -2114,7 +2209,7 @@ body[data-theme='light'] .diff-hunk {
   background: rgba(15, 15, 15, 0.32);
 }
 
-body[data-theme='light'] .diff-row {
+body[data-theme="light"] .diff-row {
   background: #ffffff;
 }
 
@@ -2127,7 +2222,7 @@ body[data-theme='light'] .diff-row {
   background: transparent;
 }
 
-body[data-theme='light'] .diff-row:nth-child(even) {
+body[data-theme="light"] .diff-row:nth-child(even) {
   background: #f4f6fb;
 }
 
@@ -2135,7 +2230,7 @@ body[data-theme='light'] .diff-row:nth-child(even) {
   background: rgba(12, 12, 12, 0.25);
 }
 
-body[data-theme='light'] .diff-row.diff-row-context {
+body[data-theme="light"] .diff-row.diff-row-context {
   background: #e2e8f0;
 }
 
@@ -2144,7 +2239,7 @@ body[data-theme='light'] .diff-row.diff-row-context {
   border-top: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-body[data-theme='light'] .diff-cell {
+body[data-theme="light"] .diff-cell {
   border-top: 1px solid rgba(203, 213, 225, 0.6);
 }
 
@@ -2156,7 +2251,7 @@ body[data-theme='light'] .diff-cell {
   border-right: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-body[data-theme='light'] .diff-cell-left {
+body[data-theme="light"] .diff-cell-left {
   border-right: 1px solid rgba(203, 213, 225, 0.6);
 }
 
@@ -2169,7 +2264,7 @@ body[data-theme='light'] .diff-cell-left {
   border-top: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-body[data-theme='light'] .diff-hunk-footer {
+body[data-theme="light"] .diff-hunk-footer {
   background: #ffffff;
   border-top: 1px solid rgba(203, 213, 225, 0.6);
   border-bottom-left-radius: 12px;
@@ -2181,7 +2276,7 @@ body[data-theme='light'] .diff-hunk-footer {
   color: #9ca3af;
 }
 
-body[data-theme='light'] .diff-hunk-summary {
+body[data-theme="light"] .diff-hunk-summary {
   color: #475569;
 }
 
@@ -2202,20 +2297,19 @@ body[data-theme='light'] .diff-hunk-summary {
   color: #93c5fd;
 }
 
-body[data-theme='light'] .diff-context-toggle {
+body[data-theme="light"] .diff-context-toggle {
   color: #2563eb;
   text-decoration-color: rgba(37, 99, 235, 0.45);
   background: white;
 }
 
-body[data-theme='light'] .diff-context-toggle:hover {
+body[data-theme="light"] .diff-context-toggle:hover {
   color: #3b82f6;
 }
 
 .diff-hunk--context-collapsed .diff-row-context {
   display: none;
 }
-
 
 .diff-line {
   display: flex;
@@ -2226,7 +2320,7 @@ body[data-theme='light'] .diff-context-toggle:hover {
   transition: background-color 0.2s ease;
 }
 
-body[data-theme='light'] .diff-line {
+body[data-theme="light"] .diff-line {
   background: rgba(255, 255, 255, 0.95);
 }
 
@@ -2247,7 +2341,7 @@ body[data-theme='light'] .diff-line {
   color: rgba(148, 163, 184, 0.6);
 }
 
-body[data-theme='light'] .diff-line-context {
+body[data-theme="light"] .diff-line-context {
   background: white;
   color: rgba(71, 85, 105, 0.75);
 }
@@ -2256,7 +2350,7 @@ body[data-theme='light'] .diff-line-context {
   background: rgba(63, 185, 80, 0.12);
 }
 
-body[data-theme='light'] .diff-line-added {
+body[data-theme="light"] .diff-line-added {
   background: rgba(63, 185, 80, 0.18);
 }
 
@@ -2264,7 +2358,7 @@ body[data-theme='light'] .diff-line-added {
   background: rgba(248, 81, 73, 0.12);
 }
 
-body[data-theme='light'] .diff-line-removed {
+body[data-theme="light"] .diff-line-removed {
   background: rgba(248, 81, 73, 0.18);
 }
 
@@ -2285,7 +2379,7 @@ body[data-theme='light'] .diff-line-removed {
   flex-shrink: 0;
 }
 
-body[data-theme='light'] .diff-line-marker {
+body[data-theme="light"] .diff-line-marker {
   color: #64748b;
 }
 
@@ -2296,7 +2390,6 @@ body[data-theme='light'] .diff-line-marker {
 .diff-line-removed .diff-line-marker {
   color: #f85149;
 }
-
 
 .diff-line-num {
   display: inline-flex;
@@ -2313,7 +2406,7 @@ body[data-theme='light'] .diff-line-marker {
   flex-shrink: 0;
 }
 
-body[data-theme='light'] .diff-line-num {
+body[data-theme="light"] .diff-line-num {
   color: rgba(100, 116, 139, 0.75);
 }
 
@@ -2326,7 +2419,7 @@ body[data-theme='light'] .diff-line-num {
   word-break: break-word;
 }
 
-body[data-theme='light'] .diff-line-text {
+body[data-theme="light"] .diff-line-text {
   color: #1f2937;
 }
 
@@ -2337,32 +2430,32 @@ body[data-theme='light'] .diff-line-text {
   color: inherit;
 }
 
-body[data-theme='light'] .diff-line-text code {
+body[data-theme="light"] .diff-line-text code {
   color: inherit;
 }
 
-body[data-theme='light'] #sortSelect,
-body[data-theme='light'] #searchBox,
-body[data-theme='light'] #scheduleFrequency,
-body[data-theme='light'] #scheduleTime,
-body[data-theme='light'] #haUrl,
-body[data-theme='light'] #haToken,
-body[data-theme='light'] #liveConfigPath,
-body[data-theme='light'] #backupFolderPath,
-body[data-theme='light'] #scheduleDay,
-body[data-theme='light'] #liveConfigPath,
-body[data-theme='light'] #backupFolderPath,
-body[data-theme='light'] #haUrl,
-body[data-theme='light'] #haToken,
-body[data-theme='light'] #maxBackupsCount {
+body[data-theme="light"] #sortSelect,
+body[data-theme="light"] #searchBox,
+body[data-theme="light"] #scheduleFrequency,
+body[data-theme="light"] #scheduleTime,
+body[data-theme="light"] #haUrl,
+body[data-theme="light"] #haToken,
+body[data-theme="light"] #liveConfigPath,
+body[data-theme="light"] #backupFolderPath,
+body[data-theme="light"] #scheduleDay,
+body[data-theme="light"] #liveConfigPath,
+body[data-theme="light"] #backupFolderPath,
+body[data-theme="light"] #haUrl,
+body[data-theme="light"] #haToken,
+body[data-theme="light"] #maxBackupsCount {
   background-color: rgba(255, 255, 255, 0.96) !important;
   border: 1px solid rgba(148, 163, 184, 0.35) !important;
   color: #0f172a !important;
   box-shadow: none !important;
 }
 
-body[data-theme='light'] #itemsList .list-item,
-body[data-theme='light'] #backupList .list-item {
+body[data-theme="light"] #itemsList .list-item,
+body[data-theme="light"] #backupList .list-item {
   background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.22);
 }
@@ -2397,8 +2490,8 @@ body[data-theme='light'] #backupList .list-item {
     border-bottom: 1px solid rgba(255, 255, 255, 0.04);
   }
 
-  body[data-theme='light'] .diff-row .diff-cell:not(:last-child),
-  body[data-theme='light'] .diff-cell-left {
+  body[data-theme="light"] .diff-row .diff-cell:not(:last-child),
+  body[data-theme="light"] .diff-cell-left {
     border-bottom: 1px solid rgba(203, 213, 225, 0.6);
   }
 }
@@ -2532,36 +2625,35 @@ body[data-theme='light'] #backupList .list-item {
   background: rgba(255, 255, 255, 0.25);
 }
 
-body[data-theme='light'] ::-webkit-scrollbar-track {
+body[data-theme="light"] ::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.05);
 }
 
-body[data-theme='light'] ::-webkit-scrollbar-thumb {
+body[data-theme="light"] ::-webkit-scrollbar-thumb {
   background: rgba(0, 0, 0, 0.2);
 }
 
-body[data-theme='light'] ::-webkit-scrollbar-thumb:hover {
+body[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
   background: rgba(0, 0, 0, 0.3);
 }
-
 
 /* Selection styling */
 ::selection {
   background: rgba(0, 122, 255, 0.3);
-  color: #F9F9F9;
+  color: #f9f9f9;
 }
 
-body[data-theme='light'] ::selection {
+body[data-theme="light"] ::selection {
   background: rgba(0, 122, 255, 0.2);
   color: #0f172a;
 }
 
 ::-moz-selection {
   background: rgba(0, 122, 255, 0.3);
-  color: #F9F9F9;
+  color: #f9f9f9;
 }
 
-body[data-theme='light'] ::-moz-selection {
+body[data-theme="light"] ::-moz-selection {
   background: rgba(0, 122, 255, 0.2);
   color: #0f172a;
 }
@@ -2585,7 +2677,7 @@ body[data-theme='light'] ::-moz-selection {
   justify-content: space-between;
 }
 
-body[data-theme='light'] .diff-header {
+body[data-theme="light"] .diff-header {
   background-color: rgba(248, 250, 252, 0.92);
   color: #0f172a;
   border-bottom: 1px solid rgba(203, 213, 225, 0.55);
@@ -2617,13 +2709,17 @@ body[data-theme='light'] .diff-header {
   border-radius: 8px;
   /* Rounded corners all sides */
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.24);
   width: calc(100% - 36px);
   box-sizing: border-box;
 }
 
-body[data-theme='light'] .diff-banners-grid--standalone {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+body[data-theme="light"] .diff-banners-grid--standalone {
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.1),
+    0 1px 2px rgba(0, 0, 0, 0.06);
 }
 
 /* Ensure the diff viewer shell has matching width and margins */
@@ -2659,7 +2755,7 @@ body[data-theme='light'] .diff-banners-grid--standalone {
   text-shadow: none;
 }
 
-body[data-theme='light'] .diff-state-banner-current {
+body[data-theme="light"] .diff-state-banner-current {
   background-color: rgba(209, 213, 219, 0.8);
   color: #6b7280;
   border-color: rgba(209, 213, 219, 0.8);
@@ -2700,7 +2796,7 @@ body[data-theme='light'] .diff-state-banner-current {
   text-align: right;
 }
 
-body[data-theme='light'] .diff-header-section--right {
+body[data-theme="light"] .diff-header-section--right {
   color: inherit;
 }
 
@@ -2717,7 +2813,7 @@ body[data-theme='light'] .diff-header-section--right {
   gap: 12px;
 }
 
-body[data-theme='light'] .modal-footer--diff {
+body[data-theme="light"] .modal-footer--diff {
   background-color: #ffffff;
   border-top: 1px solid rgba(203, 213, 225, 0.55);
 }
@@ -2732,7 +2828,7 @@ body[data-theme='light'] .modal-footer--diff {
   box-shadow: none;
 }
 
-body[data-theme='light'] .modal-footer--diff .btn-primary {
+body[data-theme="light"] .modal-footer--diff .btn-primary {
   box-shadow: none;
 }
 
@@ -2786,12 +2882,12 @@ body[data-theme='light'] .modal-footer--diff .btn-primary {
   background-color: #1e1e1e;
   color: #d1d5db;
   border: 1px solid rgba(255, 255, 255, 0.05);
-  font-family: 'Fira Code', 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+  font-family: "Fira Code", "SF Mono", "Menlo", "Monaco", "Consolas", monospace;
   line-height: 1.5;
   overflow-x: auto;
 }
 
-body[data-theme='light'] .code-viewer {
+body[data-theme="light"] .code-viewer {
   background-color: #ffffff !important;
   color: #1f2937 !important;
   border: 1px solid rgba(203, 213, 225, 0.6);
@@ -2816,12 +2912,12 @@ body[data-theme='light'] .code-viewer {
   color: #6b7280;
 }
 
-body[data-theme='light'] .file-icon-container {
+body[data-theme="light"] .file-icon-container {
   background-color: #f3f4f6;
   /* Light grey background for light theme */
 }
 
-body[data-theme='light'] .file-icon {
+body[data-theme="light"] .file-icon {
   color: #9ca3af;
   /* Slightly darker grey than background in light mode */
 }
@@ -2862,7 +2958,6 @@ input::placeholder {
 }
 
 @keyframes pulse {
-
   0%,
   100% {
     opacity: 1;
@@ -2876,11 +2971,11 @@ input::placeholder {
 }
 
 /* Ensure 21px vertical spacing between all elements in settings card */
-.settings-card>* {
+.settings-card > * {
   margin-bottom: 21px;
 }
 
-.settings-card>*:last-child {
+.settings-card > *:last-child {
   margin-bottom: 0;
 }
 
@@ -2900,11 +2995,11 @@ input::placeholder {
   background-color: rgba(60, 140, 90, 0.35);
 }
 
-body[data-theme='light'] [data-diff-palette="1"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="1"] .diff-word-removed {
   background-color: rgba(220, 38, 38, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="1"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="1"] .diff-word-added {
   background-color: rgba(22, 163, 74, 0.25);
 }
 
@@ -2917,11 +3012,11 @@ body[data-theme='light'] [data-diff-palette="1"] .diff-word-added {
   background-color: rgba(0, 191, 165, 0.35);
 }
 
-body[data-theme='light'] [data-diff-palette="2"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="2"] .diff-word-removed {
   background-color: rgba(233, 30, 99, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="2"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="2"] .diff-word-added {
   background-color: rgba(0, 191, 165, 0.3);
 }
 
@@ -2934,11 +3029,11 @@ body[data-theme='light'] [data-diff-palette="2"] .diff-word-added {
   background-color: rgba(0, 172, 193, 0.35);
 }
 
-body[data-theme='light'] [data-diff-palette="3"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="3"] .diff-word-removed {
   background-color: rgba(255, 87, 34, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="3"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="3"] .diff-word-added {
   background-color: rgba(0, 172, 193, 0.3);
 }
 
@@ -2948,14 +3043,14 @@ body[data-theme='light'] [data-diff-palette="3"] .diff-word-added {
 }
 
 [data-diff-palette="4"] .diff-word-added {
-  background-color: rgba(118, 255, 3, 0.30);
+  background-color: rgba(118, 255, 3, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="4"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="4"] .diff-word-removed {
   background-color: rgba(156, 39, 176, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="4"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="4"] .diff-word-added {
   background-color: rgba(76, 175, 80, 0.3);
 }
 
@@ -2968,11 +3063,11 @@ body[data-theme='light'] [data-diff-palette="4"] .diff-word-added {
   background-color: rgba(32, 178, 170, 0.4);
 }
 
-body[data-theme='light'] [data-diff-palette="5"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="5"] .diff-word-removed {
   background-color: rgba(250, 128, 114, 0.35);
 }
 
-body[data-theme='light'] [data-diff-palette="5"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="5"] .diff-word-added {
   background-color: rgba(32, 178, 170, 0.35);
 }
 
@@ -2985,11 +3080,11 @@ body[data-theme='light'] [data-diff-palette="5"] .diff-word-added {
   background-color: rgba(46, 125, 50, 0.4);
 }
 
-body[data-theme='light'] [data-diff-palette="6"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="6"] .diff-word-removed {
   background-color: rgba(198, 40, 40, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="6"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="6"] .diff-word-added {
   background-color: rgba(46, 125, 50, 0.3);
 }
 
@@ -3002,11 +3097,11 @@ body[data-theme='light'] [data-diff-palette="6"] .diff-word-added {
   background-color: rgba(77, 208, 225, 0.4);
 }
 
-body[data-theme='light'] [data-diff-palette="7"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="7"] .diff-word-removed {
   background-color: rgba(239, 68, 68, 0.25);
 }
 
-body[data-theme='light'] [data-diff-palette="7"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="7"] .diff-word-added {
   background-color: rgba(6, 182, 212, 0.3);
 }
 
@@ -3019,11 +3114,11 @@ body[data-theme='light'] [data-diff-palette="7"] .diff-word-added {
   background-color: rgba(0, 229, 255, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="8"] .diff-word-removed {
+body[data-theme="light"] [data-diff-palette="8"] .diff-word-removed {
   background-color: rgba(236, 72, 153, 0.3);
 }
 
-body[data-theme='light'] [data-diff-palette="8"] .diff-word-added {
+body[data-theme="light"] [data-diff-palette="8"] .diff-word-added {
   background-color: rgba(6, 182, 212, 0.3);
 }
 
@@ -3035,7 +3130,9 @@ body[data-theme='light'] [data-diff-palette="8"] .diff-word-added {
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 12px;
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
+  box-shadow:
+    0 10px 25px -5px rgba(0, 0, 0, 0.5),
+    0 8px 10px -6px rgba(0, 0, 0, 0.5);
   padding: 6px;
   z-index: 10000;
   min-width: 180px;
@@ -3063,7 +3160,9 @@ body[data-theme='light'] [data-diff-palette="8"] .diff-word-added {
   color: #ededed;
   cursor: pointer;
   border-radius: 8px;
-  transition: background-color 0.15s ease, transform 0.1s ease;
+  transition:
+    background-color 0.15s ease,
+    transform 0.1s ease;
   user-select: none;
 }
 
@@ -3133,20 +3232,22 @@ body[data-theme='light'] [data-diff-palette="8"] .diff-word-added {
   opacity: 1;
 }
 
-body[data-theme='light'] .context-menu {
+body[data-theme="light"] .context-menu {
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(0, 0, 0, 0.08);
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
-body[data-theme='light'] .context-menu-item {
+body[data-theme="light"] .context-menu-item {
   color: #1f2937;
 }
 
-body[data-theme='light'] .context-menu-item:hover {
+body[data-theme="light"] .context-menu-item:hover {
   background-color: rgba(0, 0, 0, 0.05);
 }
 
-body[data-theme='light'] .context-menu-separator {
+body[data-theme="light"] .context-menu-separator {
   background-color: rgba(0, 0, 0, 0.08);
 }


### PR DESCRIPTION
The settings dialog could overflow when the browser font size was increased, causing the Save button to move out of the viewport.

Changes:
- Updated `.modal` to allow vertical scrolling.
- Increased `.settings-card` max-height to better fit larger text sizes.
- Made `.settings-actions` sticky at the bottom to keep Save/Cancel visible.
- Removed duplicate `.settings-actions` styles.

Result:
The settings popup now scrolls properly and the Save/Cancel buttons remain accessible even with larger font sizes.