### PR TITLE
fix: resolve relative backup mount folder names to supervisor mount path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- **Fixed:** Automatically resolve relative backup mount names (e.g. `HA_TM_NAS`) to Supervisor network mount paths (`/data/mounts/...`).
+
 # v2.3.1
 
 - **Integration Updates:** You can now configure the integration directly from the Home Assistant UI, and the `time_machine.backup_now` service call now supports all available parameters for granular control.

--- a/homeassistant-time-machine/app.js
+++ b/homeassistant-time-machine/app.js
@@ -2527,10 +2527,46 @@ async function resolveFileInBackupChain(targetBackupPath, relativeFilePath) {
   }
 }
 
+// Resolves backup root path, converting relative mount names (e.g. 'HA_TM_NAS') to absolute Supervisor/system paths
+function resolveBackupRootPath(backupFolderPath) {
+  if (!backupFolderPath || typeof backupFolderPath !== 'string' || backupFolderPath.trim() === '') {
+    return '/media/timemachine';
+  }
+  const trimmed = backupFolderPath.trim();
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+  // Check Home Assistant Supervisor network mounts path (/data/mounts/<name>)
+  const supervisorMountPath = path.join('/data/mounts', trimmed);
+  try {
+    if (fs.existsSync(supervisorMountPath)) {
+      return supervisorMountPath;
+    }
+  } catch (e) {}
+
+  // Check /share/<name> and /media/<name>
+  const sharePath = path.join('/share', trimmed);
+  try {
+    if (fs.existsSync(sharePath)) {
+      return sharePath;
+    }
+  } catch (e) {}
+
+  const mediaPath = path.join('/media', trimmed);
+  try {
+    if (fs.existsSync(mediaPath)) {
+      return mediaPath;
+    }
+  } catch (e) {}
+
+  // Default to Supervisor network mount path for non-absolute folder names
+  return supervisorMountPath;
+}
+
 // Reusable backup function
 async function performBackup(liveConfigPath, backupFolderPath, source = 'manual', maxBackupsEnabled = false, maxBackupsCount = 100, timezone = null, smartBackupEnabled = false) {
   const configPath = liveConfigPath || '/config';
-  const backupRoot = backupFolderPath || '/media/timemachine';
+  const backupRoot = resolveBackupRootPath(backupFolderPath);
 
   LAST_BACKUP_STATE = {
     status: 'in_progress',
@@ -3442,7 +3478,7 @@ app.post('/api/restore-packages-file', async (req, res) => {
 app.get('/api/health', async (req, res) => {
   try {
     const options = await getAddonOptions();
-    const backupRoot = options.backupFolderPath || '/media/timemachine';
+    const backupRoot = resolveBackupRootPath(options.backupFolderPath);
     let allBackups = [];
     try {
       allBackups = await getAllBackupPaths(backupRoot);


### PR DESCRIPTION
Fixes #71. Automatically resolves relative backup mount folder names (e.g. `HA_TM_NAS`) to Supervisor network storage paths (`/data/mounts/HA_TM_NAS`).