### PR TITLE
fix: disambiguate split config items in UI list and diff viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- **Fixed:** Resolved UI sidebar duplication and blank diff display issue when comparing split configuration automations and scripts without explicit IDs or with identical aliases.
 - **Fixed:** Automatically resolve relative backup mount names (e.g. `HA_TM_NAS`) to Supervisor network mount paths (`/data/mounts/...`).
 
 # v2.3.1

--- a/homeassistant-time-machine/app.js
+++ b/homeassistant-time-machine/app.js
@@ -1767,10 +1767,37 @@ app.post('/api/get-live-items', async (req, res) => {
     }
 
     const liveItems = {};
-    itemIdentifiers.forEach(identifier => {
-      const item = allItems.find(i => (i.id === identifier || i.alias === identifier));
-      if (item) {
-        liveItems[identifier] = item;
+    const usedIndices = new Set();
+
+    (itemIdentifiers || []).forEach(itemReq => {
+      let descriptor = typeof itemReq === 'object' && itemReq !== null
+        ? itemReq
+        : { _uid: itemReq, id: itemReq, alias: itemReq };
+
+      const key = descriptor._uid || descriptor.id || descriptor.alias;
+      if (!key) return;
+
+      // 1. Try matching by id
+      let matchIdx = -1;
+      if (descriptor.id) {
+        matchIdx = allItems.findIndex((i, idx) => !usedIndices.has(idx) && i.id === descriptor.id);
+      }
+
+      // 2. Try matching by alias
+      if (matchIdx === -1 && descriptor.alias) {
+        matchIdx = allItems.findIndex((i, idx) => !usedIndices.has(idx) && i.alias === descriptor.alias);
+      }
+
+      // 3. Fallback: match by position index
+      if (matchIdx === -1 && typeof descriptor.index === 'number' && descriptor.index < allItems.length) {
+        if (!usedIndices.has(descriptor.index)) {
+          matchIdx = descriptor.index;
+        }
+      }
+
+      if (matchIdx !== -1) {
+        usedIndices.add(matchIdx);
+        liveItems[key] = allItems[matchIdx];
       }
     });
 

--- a/homeassistant-time-machine/views/index.ejs
+++ b/homeassistant-time-machine/views/index.ejs
@@ -994,7 +994,11 @@
         });
 
         const data = await response.json();
-        allItems = data.automations || data.scripts || [];
+        const rawItems = data.automations || data.scripts || [];
+        allItems = rawItems.map((item, idx) => ({
+          ...item,
+          _uid: item.id ? item.id : (item.alias ? `${item.alias}__idx_${idx}` : `item__idx_${idx}`)
+        }));
 
         if (allItems.length === 0) {
           document.getElementById('itemsList').innerHTML = `<p class="empty-state">${getStyledText('ui.itemsList.noItems', { mode: currentMode })}</p>`;
@@ -1021,7 +1025,12 @@
     // Load live items
     async function loadLiveItems() {
       try {
-        const itemIdentifiers = allItems.map(item => item.id || item.alias).filter(Boolean);
+        const itemIdentifiers = allItems.map((item, index) => ({
+          _uid: item._uid,
+          id: item.id || null,
+          alias: item.alias || null,
+          index: index
+        }));
 
         const response = await fetch(url('/api/get-live-items'), {
           method: 'POST',
@@ -1035,15 +1044,18 @@
         // Calculate statuses
         itemStatuses = {};
         allItems.forEach(item => {
-          const key = item.id || item.alias || '';
+          const key = item._uid || item.id || item.alias || '';
           if (!key) return;
 
           const liveItem = liveItemsMap[key];
           if (!liveItem) {
             itemStatuses[key] = 'deleted';
           } else {
-            const backupYaml = jsyaml.dump(item);
-            const liveYaml = jsyaml.dump(liveItem);
+            // Strip out internal _uid field when dumping YAML for clean comparison
+            const { _uid, ...cleanItem } = item;
+            const { _uid: liveUid, ...cleanLiveItem } = liveItem;
+            const backupYaml = jsyaml.dump(cleanItem);
+            const liveYaml = jsyaml.dump(cleanLiveItem);
             itemStatuses[key] = backupYaml === liveYaml ? 'unchanged' : 'changed';
           }
         });
@@ -1142,7 +1154,7 @@
       // If showOnlyChanges is enabled, also filter to show only changed/deleted items
       if (showOnlyChanges) {
         filtered = filtered.filter(item => {
-          const key = item.id || item.alias || '';
+          const key = item._uid || item.id || item.alias || '';
           const status = itemStatuses[key];
           return status === 'changed' || status === 'deleted';
         });
@@ -1163,7 +1175,7 @@
 
       filteredItemsGlobal = items;
       itemsList.innerHTML = items.map((item, idx) => {
-        const key = item.id || item.alias || '';
+        const key = item._uid || item.id || item.alias || '';
         const status = itemStatuses[key] || '';
         const isSelected = currentItemIndex === idx && activePanel === 'items';
         const isLightMode = currentTheme === 'light';
@@ -1233,11 +1245,13 @@
     // Show diff viewer
     async function showDiffViewer(item) {
       selectedItem = item;
-      const key = item.id || item.alias || '';
+      const key = item._uid || item.id || item.alias || '';
       const liveItem = liveItemsMap[key];
       const status = itemStatuses[key];
-      const backupYaml = jsyaml.dump(item);
-      const liveYaml = liveItem ? jsyaml.dump(liveItem) : null;
+      const { _uid, ...cleanItem } = item;
+      const cleanLiveItem = liveItem ? (({ _uid: liveUid, ...rest }) => rest)(liveItem) : null;
+      const backupYaml = jsyaml.dump(cleanItem);
+      const liveYaml = cleanLiveItem ? jsyaml.dump(cleanLiveItem) : null;
       const noChanges = backupYaml === liveYaml;
 
       document.getElementById('diffTitle').textContent = item.alias || item.id || 'Item';


### PR DESCRIPTION
Fixes #69. Disambiguates automations and scripts in split configuration files without explicit IDs or with duplicate aliases by generating unique item keys and tracking matched indices.